### PR TITLE
Add API functionality for Message creation.

### DIFF
--- a/boltdb.go
+++ b/boltdb.go
@@ -65,6 +65,31 @@ func (db BoltDB) GetUsers() ([]User, error) {
 	return users, nil
 }
 
+func (db BoltDB) SaveMessage(mes *Message) error {
+	err := db.Conn.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(MESSAGES))
+		if err != nil {
+			return err
+		}
+
+		return b.Put(mes.Id, []byte(mes.Body))
+	})
+	return err
+}
+
+// Delete a message from the database based on Id.
+func (db BoltDB) DeleteMessage(mes *Message) error {
+	err := db.Conn.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(MESSAGES))
+		if err != nil {
+			return err
+		}
+
+		return b.Delete(mes.Id)
+	})
+	return err
+}
+
 func (db BoltDB) SaveUser(user *User) error {
 	err := db.Conn.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(USERS))

--- a/boltdb_test.go
+++ b/boltdb_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/twinj/uuid"
 )
 
 const ID = 123
@@ -20,6 +22,29 @@ func TestBoltDBOpen(t *testing.T) {
 	_, err = BoltDBOpen(DBFILE)
 	if err == nil {
 		t.Errorf("boltdb: error expected with opening dir")
+	}
+}
+
+func TestMessageLifecycle(t *testing.T) {
+	db, err := BoltDBOpen(DBFILE)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	defer db.Conn.Close()
+
+	// TODO: Create some sort of init function to handle the calling of any
+	// necessary init requirements throughout server.
+	uuid.Init() // Must init before V1 uuids.
+	mes := NewMessage("test message body")
+	err = db.SaveMessage(mes)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = db.DeleteMessage(mes)
+	if err != nil {
+		t.Errorf(err.Error())
 	}
 }
 

--- a/dbconn.go
+++ b/dbconn.go
@@ -10,4 +10,6 @@ type DBConn interface {
 	DeleteUser(u *User) error
 	GetUserById(id int) (*User, error)
 	GetUsers() ([]User, error)
+	SaveMessage(m *Message) error
+	DeleteMessage(m *Message) error
 }

--- a/message.go
+++ b/message.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/twinj/uuid"
+)
+
+// Message holds message data and nothing more.
+// Due to the high volume of messages we use a UUID to provide the required
+// keyspace for the Id of all the messages. For messages we suggest a version 1
+// UUID based on a timestamp to keep it sequential (CSPRNG not needed for
+// message IDs.
+type Message struct {
+	Id   uuid.Uuid
+	Body string
+}
+
+// Save will store the message in the database and will return an error in case
+// of DB failure.
+func (m *Message) Save() error {
+	return db.SaveMessage(m)
+}
+
+// Delete will remove any matching record from the database permanently and will
+// return an error in case of DB failure.
+func (m *Message) Delete() error {
+	return db.DeleteMessage(m)
+}

--- a/message.go
+++ b/message.go
@@ -10,8 +10,12 @@ import (
 // UUID based on a timestamp to keep it sequential (CSPRNG not needed for
 // message IDs.
 type Message struct {
-	Id   uuid.Uuid
+	Id   uuid.Uuid `json:"-"` // We don't want people submitting their own Id.
 	Body string
+}
+
+func NewMessage(body string) *Message {
+	return &Message{Id: uuid.NewV1(), Body: body}
 }
 
 // Save will store the message in the database and will return an error in case

--- a/message.go
+++ b/message.go
@@ -14,6 +14,8 @@ type Message struct {
 	Body string
 }
 
+// NewMessage takes a string and returns a new Message with a unique Id. Message
+// must be saved for persistence.
 func NewMessage(body string) *Message {
 	return &Message{Id: uuid.NewV1(), Body: body}
 }

--- a/message_api.go
+++ b/message_api.go
@@ -1,8 +1,45 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"net/http"
 )
+
+var (
+	ErrMessageNotFound = errors.New("api: message not found")
+)
+
+func apiMessagePostHandler(w http.ResponseWriter, r *http.Request) {
+	content := r.Header.Get("Content-Type")
+	if content != "application/json" {
+		http.Error(w, ErrUnsupportedMediaType.Error(), http.StatusUnsupportedMediaType)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	mes := NewMessage("")
+	err = json.Unmarshal(body, &mes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = mes.Save()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	return
+}
 
 func apiMessageHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)

--- a/routes.go
+++ b/routes.go
@@ -26,7 +26,8 @@ func routes() *mux.Router {
 	r.HandleFunc("/api/user", apiUserGetHandler).Methods("GET")            // Get all users
 
 	// /message
-	r.HandleFunc("/api/message", apiMessageHandler) // Handle all message API requests
+	r.HandleFunc("/api/message", apiMessageHandler).Methods("GET")      // TODO: Not supported
+	r.HandleFunc("/api/message", apiMessagePostHandler).Methods("POST") // Create a message
 
 	// /auth
 	r.HandleFunc("/api/auth", apiAuthHandler) // Handle all auth API requests

--- a/routes_test.go
+++ b/routes_test.go
@@ -14,18 +14,27 @@ func TestRoutes(t *testing.T) {
 	go StartServer()
 	time.Sleep(100 * time.Millisecond)
 
+	// Test message api
 	testMessage(t)
+
+	// Test user api
 	testUser(t)
+
+	// Test auth api
 	testAuth(t)
 }
 
 func testMessage(t *testing.T) {
+	// GET /api/message
 	// TODO: Decide on proper response and functionality for GET /api/message
 	r := Get("/api/message", t)
 	if r != 200 {
 		t.Errorf("GET /api/message did not return 200, instead returned %d\n", r)
 	}
 
+	// POST /api/message
+	// Creates a new message with the given body parameter.
+	// Should return 201 on successful creation or 5** for server error.
 	r = Post("/api/message", "{\"body\": \"This is the body of the first message.\"}", t)
 	if r != 201 {
 		t.Errorf("POST /api/message did not return 201, instead returned %d\n", r)
@@ -33,45 +42,64 @@ func testMessage(t *testing.T) {
 }
 
 func testUser(t *testing.T) {
+	// GET /api/user
+	// TODO: Decide on use of this call. Is it needed?
 	r := Get("/api/user", t)
 	if r != 200 {
 		t.Errorf("GET /api/user did not return 200, instead returned %d\n", r)
 	}
 
+	// PUT /api/user/{id}
+	// Create a new user or update a user record.
+	// Should return 201 on successful creation, 200 on update, or 5** for server error.
 	r = Put("/api/user/321", "{\"id\": 321, \"username\":\"fdsa\", \"password\": \"fdsa\"}", t)
 	if r != 201 {
 		t.Errorf("PUT /api/user/321 did not return 201, instead returned %d\n", r)
 	}
 
+	// GET /api/user/{id}
+	// Returns the given user resource
+	// Should return 200 if found or 404 if resource isn't found.
 	r = Get("/api/user/321", t)
 	if r != 200 {
 		t.Errorf("GET /api/user/321 did not return 200, instead returned %d\n", r)
 	}
 
+	// POST /api/user
+	// Create a new user
+	// TODO: Remove id from this and generate a unique one automatically.
+	// Should return 201 for created or 409 for conflict.
 	r = Post("/api/user", "{\"id\": 123, \"username\":\"asdf\", \"password\": \"fdsa\"}", t)
 	if r != 201 && r != 409 {
 		t.Errorf("POST /api/user did not return 201, instead returned %d\n", r)
 	}
 
+	// Get newly created user.
 	r = Get("/api/user/123", t)
 	if r != 200 {
 		t.Errorf("GET /api/user/123 did not return 200, instead returned %d\n", r)
 	}
 
+	// Update the user's record.
 	r = Put("/api/user/123", "{\"id\": 123, \"username\":\"fdsa\", \"password\": \"fdsa\"}", t)
 	if r != 200 {
 		t.Errorf("PUT /api/user/123 did not return 200, instead returned %d\n", r)
 	}
 
+	// DELETE /api/user/{id}
+	// Delete's the user resource.
+	// Should return 204 for deletion, 404 if not found, or 5** for server error
 	r = Delete("/api/user/123", t)
 	if r != 204 {
 		t.Errorf("DELETE did not return 204, instead returned %d\n", r)
 	}
 
+	// Delete user record.
 	r = Delete("/api/user/321", t)
 	if r != 204 {
 		t.Errorf("DELETE did not return 204, instead returned %d\n", r)
 	}
+
 	// Test delete on non existant user
 	r = Delete("/api/user/1337", t)
 	if r != 404 {
@@ -80,6 +108,9 @@ func testUser(t *testing.T) {
 }
 
 func testAuth(t *testing.T) {
+	// GET /api/auth
+	// TODO: Will return an auth token or something eventually...
+	// Should return 405 unauthorized until implemented.
 	r := Get("/api/auth", t)
 	if r != 405 {
 		t.Errorf("GET /api/auth did not return 405, instead returned %d\n", r)

--- a/routes_test.go
+++ b/routes_test.go
@@ -26,7 +26,7 @@ func testMessage(t *testing.T) {
 		t.Errorf("GET /api/message did not return 200, instead returned %d\n", r)
 	}
 
-	r := Post("/api/message", "{\"body\": \"This is the body of the first message.\"}", t)
+	r = Post("/api/message", "{\"body\": \"This is the body of the first message.\"}", t)
 	if r != 201 {
 		t.Errorf("POST /api/message did not return 201, instead returned %d\n", r)
 	}
@@ -65,10 +65,17 @@ func testUser(t *testing.T) {
 
 	r = Delete("/api/user/123", t)
 	if r != 204 {
-		if r == 404 {
-			t.Errorf("DELETE on user not found\n")
-		}
 		t.Errorf("DELETE did not return 204, instead returned %d\n", r)
+	}
+
+	r = Delete("/api/user/321", t)
+	if r != 204 {
+		t.Errorf("DELETE did not return 204, instead returned %d\n", r)
+	}
+	// Test delete on non existant user
+	r = Delete("/api/user/1337", t)
+	if r != 404 {
+		t.Errorf("DELETE on user not found\n")
 	}
 }
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -117,6 +117,7 @@ func testAuth(t *testing.T) {
 	}
 }
 
+// Make a GET request to the specified path.
 func Get(path string, t *testing.T) int {
 	get_url := fmt.Sprintf("http://127.0.0.1:8080%s", path)
 	res, err := http.Get(get_url)
@@ -130,6 +131,7 @@ func Get(path string, t *testing.T) int {
 	return res.StatusCode
 }
 
+// Make a POST request to the specified path and with the given JSON body.
 func Post(path, body string, t *testing.T) int {
 	post_url := fmt.Sprintf("http://127.0.0.1:8080%s", path)
 	bodyType := "application/json"
@@ -144,6 +146,7 @@ func Post(path, body string, t *testing.T) int {
 	return res.StatusCode
 }
 
+// Make a PUT request to the specified path with the given JSON body
 func Put(path, body string, t *testing.T) int {
 	put_url := fmt.Sprintf("http://127.0.0.1:8080%s", path)
 	bodyType := "application/json"
@@ -153,6 +156,7 @@ func Put(path, body string, t *testing.T) int {
 		return 0
 	}
 
+	// Add a header for JSON content type
 	req.Header.Add("Content-Type", bodyType)
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -165,6 +169,7 @@ func Put(path, body string, t *testing.T) int {
 	return res.StatusCode
 }
 
+// Make a DELETE request to the given path.
 func Delete(path string, t *testing.T) int {
 	del_url := fmt.Sprintf("http://127.0.0.1:8080%s", path)
 	req, err := http.NewRequest("DELETE", del_url, strings.NewReader(""))

--- a/routes_test.go
+++ b/routes_test.go
@@ -20,9 +20,15 @@ func TestRoutes(t *testing.T) {
 }
 
 func testMessage(t *testing.T) {
+	// TODO: Decide on proper response and functionality for GET /api/message
 	r := Get("/api/message", t)
 	if r != 200 {
 		t.Errorf("GET /api/message did not return 200, instead returned %d\n", r)
+	}
+
+	r := Post("/api/message", "{\"body\": \"This is the body of the first message.\"}", t)
+	if r != 201 {
+		t.Errorf("POST /api/message did not return 201, instead returned %d\n", r)
 	}
 }
 


### PR DESCRIPTION
This includes a test for message creation and also fixes a test a failing User test case. (should have been separate commits yada yada, got carried away.

GET /api/message - Should always return 200 as a placeholder
POST /api/message - 201 on creation unless error