### PR TITLE
Enforce username uniqueness at the database level.

### DIFF
--- a/boltdb.go
+++ b/boltdb.go
@@ -156,7 +156,19 @@ func (db BoltDB) SaveUser(user *User) error {
 		return ErrUserObjectNil
 	}
 
-	err := db.Conn.Update(func(tx *bolt.Tx) error {
+	u1, err := db.GetUserByUsername(user.Username)
+
+	// If we find a user with that username
+	if err != ErrUserNotFound {
+		// Not the same user?
+		if u1.Id != user.Id {
+			// Conflict
+			return ErrUsernameAlreadyExists
+		}
+	}
+
+	// If everything seems ok otherwise, attempt to save them
+	err = db.Conn.Update(func(tx *bolt.Tx) error {
 		encoded := MarshalUser(user)
 
 		b := tx.Bucket([]byte(USERIDS))

--- a/routes_test.go
+++ b/routes_test.go
@@ -89,6 +89,13 @@ func testUser(t *testing.T) {
 		t.Errorf("GET /api/user/%s did not return 200, instead returned %d\n", user.Id, r)
 	}
 
+	// Update the user's record with a conflicting username.
+	// Should fail
+	r = Put("/api/user/"+user.Id, "{\"id\": \""+user.Id+"\", \"username\":\"fdsa\", \"password\": \"farts\"}", t)
+	if r != 409 {
+		t.Errorf("PUT /api/user/%s did not return 409, instead returned %d\n", user.Id, r)
+	}
+
 	// Update the user's record.
 	r = Put("/api/user/"+user.Id, "{\"id\": \""+user.Id+"\", \"username\":\"asdf\", \"password\": \"farts\"}", t)
 	if r != 200 {

--- a/user.go
+++ b/user.go
@@ -29,6 +29,23 @@ func NewUser(username, password string) (*User, error) {
 }
 
 func (u *User) Save() error {
+	existing, err := db.GetUserByUsername(u.Username)
+
+	if err != nil {
+		// If User doesn't yet exist, we're good to go
+		if err == ErrUserNotFound {
+			return db.SaveUser(u)
+		}
+		// Some other error is no bueno
+		return err
+	}
+
+	// If the username belongs to a different User ID we fail
+	if existing.Id != u.Id {
+		return ErrUsernameAlreadyExists
+	}
+
+	// Otherwise they should match and we should be good.
 	return db.SaveUser(u)
 }
 

--- a/user.go
+++ b/user.go
@@ -29,23 +29,6 @@ func NewUser(username, password string) (*User, error) {
 }
 
 func (u *User) Save() error {
-	existing, err := db.GetUserByUsername(u.Username)
-
-	if err != nil {
-		// If User doesn't yet exist, we're good to go
-		if err == ErrUserNotFound {
-			return db.SaveUser(u)
-		}
-		// Some other error is no bueno
-		return err
-	}
-
-	// If the username belongs to a different User ID we fail
-	if existing.Id != u.Id {
-		return ErrUsernameAlreadyExists
-	}
-
-	// Otherwise they should match and we should be good.
 	return db.SaveUser(u)
 }
 


### PR DESCRIPTION
Added an API test (routes_test) for checking username conflict. Turned out it wasn't passing so I enforced uniqueness at User.Save() and at db.SaveUser().